### PR TITLE
Implemented Member ID support unique to server or driver. 

### DIFF
--- a/bin/benchmark-drivers-start.sh
+++ b/bin/benchmark-drivers-start.sh
@@ -126,7 +126,7 @@ do
 
     now=`date +'%H%M%S'`
 
-    cfg="${outFol} ${host_name0} ${CONFIG}"
+    cfg="${outFol} ${host_name0} -id ${cntr} ${CONFIG}"
 
     suffix=`echo "${cfg}" | tail -c 60 | sed 's/ *$//g'`
 

--- a/bin/benchmark-manual-drivers-start.sh
+++ b/bin/benchmark-manual-drivers-start.sh
@@ -114,7 +114,7 @@ for cfg in "${configs0[@]}";
 do
     now=`date +'%H%M%S'`
 
-    cfgParams="${OUTPUT_FOLDER} ${cfg}"
+    cfgParams="${OUTPUT_FOLDER} -id ${cntr} ${cfg}"
 
     suffix=`echo "${cfgParams}" | tail -c 60 | sed 's/ *$//g'`
 

--- a/bin/benchmark-manual-servers-start.sh
+++ b/bin/benchmark-manual-servers-start.sh
@@ -122,6 +122,8 @@ CUR_DIR=$(pwd)
 
 for i in $(eval echo {1..$SERVER_NODES});
 do
+    CONFIG_PRM="-id ${cntr} ${CONFIG}"
+
     suffix=`echo "${CONFIG}" | tail -c 60 | sed 's/ *$//g'`
 
     file_log=${LOGS_DIR}"/"${i}"_server.log"
@@ -131,5 +133,5 @@ do
 
     MAIN_CLASS=org.yardstickframework.BenchmarkServerStartUp JVM_OPTS=${JVM_OPTS} CP=${CP} \
     CUR_DIR=${CUR_DIR} PROPS_ENV0=${PROPS_ENV} \
-    nohup ${SCRIPT_DIR}/benchmark-bootstrap.sh ${CONFIG} --config ${CONFIG_INCLUDE} > ${file_log} 2>& 1 &
+    nohup ${SCRIPT_DIR}/benchmark-bootstrap.sh ${CONFIG_PRM} --config ${CONFIG_INCLUDE} > ${file_log} 2>& 1 &
 done

--- a/bin/benchmark-servers-start.sh
+++ b/bin/benchmark-servers-start.sh
@@ -108,6 +108,8 @@ cntr=0
 IFS=',' read -ra hosts0 <<< "${SERVER_HOSTS}"
 for host_name in "${hosts0[@]}";
 do
+    CONFIG_PRM="-id ${cntr} ${CONFIG}"
+
     suffix=`echo "${CONFIG}" | tail -c 60 | sed 's/ *$//g'`
 
     echo "<"$(date +"%H:%M:%S")"><yardstick> Starting server config '..."${suffix}"' on "${host_name}""
@@ -119,7 +121,7 @@ do
     ssh -o PasswordAuthentication=no ${REMOTE_USER}"@"${host_name} \
         "MAIN_CLASS='org.yardstickframework.BenchmarkServerStartUp'" "JVM_OPTS='${JVM_OPTS}'" "CP='${CP}'" \
         "CUR_DIR='${CUR_DIR}'" "PROPS_ENV0='${PROPS_ENV}'" \
-        "nohup ${SCRIPT_DIR}/benchmark-bootstrap.sh ${CONFIG} "--config" ${CONFIG_INCLUDE} > ${file_log} 2>& 1 &"
+        "nohup ${SCRIPT_DIR}/benchmark-bootstrap.sh ${CONFIG_PRM} "--config" ${CONFIG_INCLUDE} > ${file_log} 2>& 1 &"
 
     cntr=$((1 + $cntr))
 done

--- a/src/main/java/org/yardstickframework/BenchmarkConfiguration.java
+++ b/src/main/java/org/yardstickframework/BenchmarkConfiguration.java
@@ -38,6 +38,10 @@ public class BenchmarkConfiguration {
     private String serverName;
 
     /** */
+    @Parameter(names = {"-id", "--memberId"}, description = "Memebr ID")
+    private int memberId = 0;
+    
+    /** */
     @Parameter(names = {"-p", "--packages"}, description = "Comma separated list of packages for benchmarks")
     private List<String> packages = Collections.emptyList();
 
@@ -130,6 +134,13 @@ public class BenchmarkConfiguration {
         return driverNames;
     }
 
+    /**
+     * @return Member ID unique to server or driver.  
+     */
+    public int memberId() {
+        return memberId;
+    }
+    
     /**
      * @return List of packages to load benchmarks from.
      */

--- a/src/main/java/org/yardstickframework/examples/echo/EchoBenchmark.java
+++ b/src/main/java/org/yardstickframework/examples/echo/EchoBenchmark.java
@@ -14,6 +14,8 @@
 
 package org.yardstickframework.examples.echo;
 
+import static org.yardstickframework.BenchmarkUtils.println;
+
 import org.yardstickframework.*;
 
 import java.io.*;
@@ -38,7 +40,9 @@ public class EchoBenchmark extends BenchmarkDriverAdapter {
     /** {@inheritDoc} */
     @Override public void setUp(BenchmarkConfiguration cfg) throws Exception {
         super.setUp(cfg);
-
+        
+        println("Configuring driver id=" + cfg.memberId());
+        
         BenchmarkUtils.jcommander(cfg.commandLineArguments(), args, "<echo-driver>");
 
         // Check if EchoServer is up.

--- a/src/main/java/org/yardstickframework/examples/echo/EchoServer.java
+++ b/src/main/java/org/yardstickframework/examples/echo/EchoServer.java
@@ -34,7 +34,9 @@ public class EchoServer implements BenchmarkServer {
     /** {@inheritDoc} */
     @Override public void start(final BenchmarkConfiguration cfg) throws Exception {
         BenchmarkUtils.jcommander(cfg.commandLineArguments(), args, "<echo-server>");
-
+        
+        println("Configuring server id=" + cfg.memberId());
+        
         th = new Thread(new Runnable() {
             @Override public void run() {
                 try (ServerSocket srvrSock = newServerSocket(args)) {


### PR DESCRIPTION
While implementing yardstick support for my product, i wanted to distiguish between servers and wanted to implement one out of many server in a specific way, however i could not find any way to do this. 

Thus i added MemberID for each member in yardstick which is unique to Servers (Or Drivers). They can now be distinguish between themselves using this MemberID.

Added print statement in Server `Configuring server id=` and Driver`Configuring driver id=` inside EchoBenchmark example and found following output

```
$ grep "Configuring server" * -r
logs_servers/0_localhost.log:<16:42:11><yardstick> Configuring server id=0
logs_servers/1_localhost.log:<16:42:21><yardstick> Configuring server id=1

$ grep "Configuring driver" * -r
logs_drivers/164224_0_localhost.log:<16:42:34><yardstick> Configuring driver id=0
logs_drivers/164241_1_localhost.log:<16:42:51><yardstick> Configuring driver id=1
```
