### PR TITLE
Fix ID parameter when manually starting servers

### DIFF
--- a/bin/benchmark-manual-servers-start.sh
+++ b/bin/benchmark-manual-servers-start.sh
@@ -119,7 +119,7 @@ CUR_DIR=$(pwd)
 
 for id in $(eval echo {1..$SERVER_NODES});
 do
-    CONFIG_PRM="-id ${cntr} ${CONFIG}"
+    CONFIG_PRM="-id ${id} ${CONFIG}"
 
     suffix=`echo "${CONFIG}" | tail -c 60 | sed 's/ *$//g'`
 


### PR DESCRIPTION
Variable "id" is incorrectly used within the script. Trying to run the benchmark with default parameters throws:

> Exception in thread "main" com.beust.jcommander.ParameterException: "-id": couldn't convert "-cfg" to an integer
	at com.beust.jcommander.converters.IntegerConverter.convert(IntegerConverter.java:38)
	at com.beust.jcommander.converters.IntegerConverter.convert(IntegerConverter.java:28)
	at com.beust.jcommander.JCommander.convertValue(JCommander.java:1284)
	at com.beust.jcommander.JCommander.convertValue(JCommander.java:1211)
	at com.beust.jcommander.ParameterDescription.addValue(ParameterDescription.java:242)
	at com.beust.jcommander.ParameterDescription.addValue(ParameterDescription.java:210)
	at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:867)
	at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:849)
	at com.beust.jcommander.JCommander.parseValues(JCommander.java:721)
	at com.beust.jcommander.JCommander.parse(JCommander.java:281)
	at com.beust.jcommander.JCommander.parse(JCommander.java:264)
	at org.yardstickframework.BenchmarkUtils.jcommander(BenchmarkUtils.java:70)
	at org.yardstickframework.BenchmarkServerStartUp.main(BenchmarkServerStartUp.java:36)
