### PR TITLE
Add filename pattern at start scripts to use filename at the any JVM params

### DIFF
--- a/bin/benchmark-drivers-start.sh
+++ b/bin/benchmark-drivers-start.sh
@@ -160,6 +160,13 @@ do
         JVM_OPTS=${JVM_OPTS}" -Xloggc:${LOGS_DIR}/gc-${now}-driver-id${id}-${host_name}-${DS}.log"
     fi
 
+    if [[ ${JVM_OPTS} == *"#filename#"* ]]
+    then
+        filename_ptrn="${LOGS_DIR}/${now0}-driver-id${id}-${host_name}-${DS}"
+        JVM_OPTS="$(echo $JVM_OPTS | sed s=#filename#=${filename_ptrn}=g)"
+    fi
+
+
     export JAVA_HOME=${JAVA_HOME}
     export MAIN_CLASS='org.yardstickframework.BenchmarkDriverStartUp'
     export JVM_OPTS="${JVM_OPTS}${DRIVER_JVM_OPTS} -Dyardstick.driver${id}"

--- a/bin/benchmark-drivers-start.sh
+++ b/bin/benchmark-drivers-start.sh
@@ -119,6 +119,8 @@ drvNum=$((`echo ${DRIVER_HOSTS} | tr ',' '\n' | wc -l`))
 
 IFS=',' read -ra hosts0 <<< "${DRIVER_HOSTS}"
 
+JVM_OPTS_ORIG="$JVM_OPTS"
+
 for host_name in "${hosts0[@]}";
 do
     if ((${drvNum} > 1)); then
@@ -163,7 +165,7 @@ do
     if [[ ${JVM_OPTS} == *"#filename#"* ]]
     then
         filename_ptrn="${LOGS_DIR}/${now0}-driver-id${id}-${host_name}-${DS}"
-        JVM_OPTS="$(echo $JVM_OPTS | sed s=#filename#=${filename_ptrn}=g)"
+        JVM_OPTS="$(echo $JVM_OPTS_ORIG | sed s=#filename#=${filename_ptrn}=g)"
     fi
 
 

--- a/bin/benchmark-drivers-start.sh
+++ b/bin/benchmark-drivers-start.sh
@@ -157,15 +157,15 @@ do
 
     file_log=${LOGS_DIR}"/"${now}"-id"${id}"-"${host_name}"-"${DS}".log"
 
-    if [[ ${JVM_OPTS} == *"PrintGC"* ]]
-    then
-        JVM_OPTS=${JVM_OPTS}" -Xloggc:${LOGS_DIR}/gc-${now}-driver-id${id}-${host_name}-${DS}.log"
-    fi
-
     if [[ ${JVM_OPTS} == *"#filename#"* ]]
     then
         filename_ptrn="${LOGS_DIR}/${now0}-driver-id${id}-${host_name}-${DS}"
         JVM_OPTS="$(echo $JVM_OPTS_ORIG | sed s=#filename#=${filename_ptrn}=g)"
+    fi
+
+    if [[ ${JVM_OPTS} == *"PrintGC"* ]]
+    then
+        JVM_OPTS=${JVM_OPTS}" -Xloggc:${LOGS_DIR}/gc-${now}-driver-id${id}-${host_name}-${DS}.log"
     fi
 
 

--- a/bin/benchmark-servers-start.sh
+++ b/bin/benchmark-servers-start.sh
@@ -144,6 +144,12 @@ do
         JVM_OPTS=${JVM_OPTS}" -Xloggc:${LOGS_DIR}/gc-${now}-server-id${id}-${host_name}-${DS}.log"
     fi
 
+    if [[ ${JVM_OPTS} == *"#filename#"* ]]
+    then
+        filename_ptrn=${LOGS_DIR}/${now0}-server-id${id}-${host_name}-${DS}
+        JVM_OPTS="$(echo $JVM_OPTS | sed s=#filename#=${filename_ptrn}=g)"
+    fi
+
     export JAVA_HOME=${JAVA_HOME}
     export MAIN_CLASS='org.yardstickframework.BenchmarkServerStartUp'
     export JVM_OPTS="${JVM_OPTS}${SERVER_JVM_OPTS} -Dyardstick.server${id}"

--- a/bin/benchmark-servers-start.sh
+++ b/bin/benchmark-servers-start.sh
@@ -113,6 +113,9 @@ DS=""
 id=0
 
 IFS=',' read -ra hosts0 <<< "${SERVER_HOSTS}"
+
+JVM_OPTS_ORIG="$JVM_OPTS"
+
 for host_name in "${hosts0[@]}";
 do
     CONFIG_PRM="-id ${id} ${CONFIG}"
@@ -144,10 +147,10 @@ do
         JVM_OPTS=${JVM_OPTS}" -Xloggc:${LOGS_DIR}/gc-${now}-server-id${id}-${host_name}-${DS}.log"
     fi
 
-    if [[ ${JVM_OPTS} == *"#filename#"* ]]
+    if [[ ${JVM_OPTS_ORIG} == *"#filename#"* ]]
     then
         filename_ptrn=${LOGS_DIR}/${now0}-server-id${id}-${host_name}-${DS}
-        JVM_OPTS="$(echo $JVM_OPTS | sed s=#filename#=${filename_ptrn}=g)"
+        JVM_OPTS="$(echo $JVM_OPTS_ORIG | sed s=#filename#=${filename_ptrn}=g)"
     fi
 
     export JAVA_HOME=${JAVA_HOME}

--- a/bin/benchmark-servers-start.sh
+++ b/bin/benchmark-servers-start.sh
@@ -142,15 +142,15 @@ do
 
     file_log=${LOGS_DIR}"/"${now}"-id"${id}"-"${host_name}"-"${DS}".log"
 
-    if [[ ${JVM_OPTS} == *"PrintGC"* ]]
-    then
-        JVM_OPTS=${JVM_OPTS}" -Xloggc:${LOGS_DIR}/gc-${now}-server-id${id}-${host_name}-${DS}.log"
-    fi
-
     if [[ ${JVM_OPTS_ORIG} == *"#filename#"* ]]
     then
         filename_ptrn=${LOGS_DIR}/${now0}-server-id${id}-${host_name}-${DS}
         JVM_OPTS="$(echo $JVM_OPTS_ORIG | sed s=#filename#=${filename_ptrn}=g)"
+    fi
+
+    if [[ ${JVM_OPTS} == *"PrintGC"* ]]
+    then
+        JVM_OPTS=${JVM_OPTS}" -Xloggc:${LOGS_DIR}/gc-${now}-server-id${id}-${host_name}-${DS}.log"
     fi
 
     export JAVA_HOME=${JAVA_HOME}


### PR DESCRIPTION
This patch is used for configure any log files at JVM_OPTS, e.g.:
-XX:+FlightRecorder -XX:StartFlightRecording=delay=300s,duration=120s,filename=#filename#.jfr 
