### PR TITLE
Set true/false for RESTART_SERVERS (empty/not empty before)

### DIFF
--- a/bin/benchmark-run-all.sh
+++ b/bin/benchmark-run-all.sh
@@ -127,7 +127,6 @@ fi
 
 
 if [[ "$RESTART_SERVERS" == "false" ]]; then
-    echo "First condition"
     /bin/bash ${SCRIPT_DIR}/benchmark-servers-start.sh ${CONFIG_INCLUDE}
 
     sleep 3s
@@ -146,7 +145,6 @@ do
     export OUTPUT_FOLDER
 
     if [[ "$RESTART_SERVERS" == "true" || "$RESTART_SERVERS" != "" ]] && [[ "$RESTART_SERVERS" != "false" ]]; then
-        echo "Second condition"
         /bin/bash ${SCRIPT_DIR}/benchmark-servers-start.sh ${CONFIG_INCLUDE}
 
         sleep 3s

--- a/bin/benchmark-run-all.sh
+++ b/bin/benchmark-run-all.sh
@@ -121,7 +121,13 @@ LOGS_BASE=${SCRIPT_DIR}/../output/$log_dir_name
 
 export LOGS_BASE
 
-if [ -z "$RESTART_SERVERS" ]; then
+if [[ "$RESTART_SERVERS" == "" ]]; then
+    RESTART_SERVERS="true"
+fi
+
+
+if [[ "$RESTART_SERVERS" == "false" ]]; then
+    echo "First condition"
     /bin/bash ${SCRIPT_DIR}/benchmark-servers-start.sh ${CONFIG_INCLUDE}
 
     sleep 3s
@@ -139,7 +145,8 @@ do
     export CONFIG
     export OUTPUT_FOLDER
 
-    if [ -n "$RESTART_SERVERS" ]; then
+    if [[ "$RESTART_SERVERS" == "true" || "$RESTART_SERVERS" != "" ]] && [[ "$RESTART_SERVERS" != "false" ]]; then
+        echo "Second condition"
         /bin/bash ${SCRIPT_DIR}/benchmark-servers-start.sh ${CONFIG_INCLUDE}
 
         sleep 3s
@@ -147,14 +154,14 @@ do
 
     /bin/bash ${SCRIPT_DIR}/benchmark-drivers-start.sh ${CONFIG_INCLUDE}
 
-    if [ -n "$RESTART_SERVERS" ]; then
+    if [[ "$RESTART_SERVERS" == "true" ]]; then
         /bin/bash ${SCRIPT_DIR}/benchmark-servers-stop.sh ${CONFIG_INCLUDE}
 
         sleep 1s
     fi
 done
 
-if [ -z "$RESTART_SERVERS" ]; then
+if [[ "$RESTART_SERVERS" == "false" ]]; then
     /bin/bash ${SCRIPT_DIR}/benchmark-servers-stop.sh ${CONFIG_INCLUDE}
 
     sleep 1s

--- a/bin/benchmark-run-all.sh
+++ b/bin/benchmark-run-all.sh
@@ -144,7 +144,7 @@ do
     export CONFIG
     export OUTPUT_FOLDER
 
-    if [[ "$RESTART_SERVERS" == "true" || "$RESTART_SERVERS" != "" ]] && [[ "$RESTART_SERVERS" != "false" ]]; then
+    if [[ "$RESTART_SERVERS" != "false" ]]; then
         /bin/bash ${SCRIPT_DIR}/benchmark-servers-start.sh ${CONFIG_INCLUDE}
 
         sleep 3s

--- a/bin/benchmark-run-all.sh
+++ b/bin/benchmark-run-all.sh
@@ -122,7 +122,7 @@ LOGS_BASE=${SCRIPT_DIR}/../output/$log_dir_name
 export LOGS_BASE
 
 if [[ "$RESTART_SERVERS" == "" ]]; then
-    RESTART_SERVERS="true"
+    RESTART_SERVERS="false"
 fi
 
 

--- a/bin/benchmark-run-all.sh
+++ b/bin/benchmark-run-all.sh
@@ -152,7 +152,7 @@ do
 
     /bin/bash ${SCRIPT_DIR}/benchmark-drivers-start.sh ${CONFIG_INCLUDE}
 
-    if [[ "$RESTART_SERVERS" == "true" ]]; then
+    if [[ "$RESTART_SERVERS" != "false" ]]; then
         /bin/bash ${SCRIPT_DIR}/benchmark-servers-stop.sh ${CONFIG_INCLUDE}
 
         sleep 1s

--- a/bin/benchmark-server-restarter-start.sh
+++ b/bin/benchmark-server-restarter-start.sh
@@ -60,6 +60,10 @@ chmod +x $CONFIG_TMP
 . $CONFIG_TMP
 rm $CONFIG_TMP
 
+if [[ "$RESTART_SERVERS" == "" ]]; then
+    RESTART_SERVERS="false"
+fi
+
 # Define user to establish remote ssh session.
 if [ "${REMOTE_USER}" == "" ]; then
     REMOTE_USER=$(whoami)

--- a/bin/benchmark-server-restarter-start.sh
+++ b/bin/benchmark-server-restarter-start.sh
@@ -123,7 +123,7 @@ if [[ ${HOST_NAME} = "127.0.0.1" || ${HOST_NAME} = "localhost" ]]
 DS=""
 
 # Extract description.
-if [[ "${RESTART_SERVERS}" != "" ]]; then
+if [[ "${RESTART_SERVERS}" != "false" ]]; then
     IFS=' ' read -ra cfg0 <<< "${CONFIG}"
     for cfg00 in "${cfg0[@]}";
     do

--- a/bin/benchmark-servers-start.sh
+++ b/bin/benchmark-servers-start.sh
@@ -106,7 +106,7 @@ if [ "${RESTARTERS_LOGS_DIR}" = "" ]; then
     RESTARTERS_LOGS_DIR=${LOGS_BASE}/logs_restarters
 fi
 
-if [[ "${RESTART_SERVERS}" != "false" ]] && [[ "${RESTART_SERVERS}" != "true" ]] && [[ "${RESTART_SERVERS}" != "" ]]; then
+if [[ "${RESTART_SERVERS}" != "false" ]] && [[ "${RESTART_SERVERS}" != "true" ]]; then
     mkdir -p ${RESTARTERS_LOGS_DIR}
 fi
 

--- a/bin/benchmark-servers-start.sh
+++ b/bin/benchmark-servers-start.sh
@@ -102,7 +102,7 @@ if [ "${RESTARTERS_LOGS_DIR}" = "" ]; then
     RESTARTERS_LOGS_DIR=${LOGS_BASE}/logs_restarters
 fi
 
-if [[ "${RESTART_SERVERS}" != "" ]] && [[ "${RESTART_SERVERS}" != "true" ]]; then
+if [[ "${RESTART_SERVERS}" != "false" ]] && [[ "${RESTART_SERVERS}" != "true" ]] && [[ "${RESTART_SERVERS}" != "" ]]; then
     mkdir -p ${RESTARTERS_LOGS_DIR}
 fi
 
@@ -176,7 +176,7 @@ do
     fi
 
     # Start a restarter if needed.
-    if [[ "${RESTART_SERVERS}" != "" ]] && [[ "${RESTART_SERVERS}" != "true" ]]; then
+    if [[ "${RESTART_SERVERS}" != "true" ]] && [[ "${RESTART_SERVERS}" != "false" ]]; then
         IFS=',' read -ra hostsToRestart0 <<< "${RESTART_SERVERS}"
         for host2Timeout in "${hostsToRestart0[@]}";
         do

--- a/bin/benchmark-servers-start.sh
+++ b/bin/benchmark-servers-start.sh
@@ -50,6 +50,10 @@ chmod +x $CONFIG_TMP
 . $CONFIG_TMP
 rm $CONFIG_TMP
 
+if [[ "$RESTART_SERVERS" == "" ]]; then
+    RESTART_SERVERS="false"
+fi
+
 # Define user to establish remote ssh session.
 if [ "${REMOTE_USER}" == "" ]; then
     REMOTE_USER=$(whoami)

--- a/bin/benchmark-servers-stop.sh
+++ b/bin/benchmark-servers-stop.sh
@@ -69,7 +69,7 @@ fi
 
 pkill -9 -f "benchmark-server-restarter-start.sh"
 
-if [[ "${RESTART_SERVERS}" != "" ]] && [[ "${RESTART_SERVERS}" != "true" ]]; then
+if [[ "${RESTART_SERVERS}" != "true" ]] && [[ "${RESTART_SERVERS}" != "false" ]]; then
     echo "<"$(date +"%H:%M:%S")"><yardstick> All server restartets are stopped."
 fi
 

--- a/bin/benchmark-servers-stop.sh
+++ b/bin/benchmark-servers-stop.sh
@@ -50,6 +50,10 @@ chmod +x $CONFIG_TMP
 . $CONFIG_TMP
 rm $CONFIG_TMP
 
+if [[ "$RESTART_SERVERS" == "" ]]; then
+    RESTART_SERVERS="false"
+fi
+
 # Define user to establish remote ssh session.
 if [ "${REMOTE_USER}" == "" ]; then
     REMOTE_USER=$(whoami)


### PR DESCRIPTION
I've updated several yardstick scripts and tested 4 scenarios:
1.  RESTART_SERVERS=true ---> All servers will be restarted after each benchmark
2. RESTART_SERVERS=false ---> All servers will be started only 1 time on the start of the run and will be stopped after all benchmarks
3. RESTART_SERVERS=ip:id:delay:pause:period --> 1 server with <id> on host with <ip> will be restarted several times=((duration + warmup)-delay)/(pause+period)
4. RESTART_SERVERS="" - the same behavior with p.1

For testing, you can build ignite yardstick on some branch and get bin directory from this PR.