### PR TITLE
Fix benchmark-manual-servers-start.sh script

### DIFF
--- a/bin/benchmark-manual-servers-start.sh
+++ b/bin/benchmark-manual-servers-start.sh
@@ -125,7 +125,7 @@ CUR_DIR=$(pwd)
 
 for id in $(eval echo {1..$SERVER_NODES});
 do
-    CONFIG_PRM="-id ${cntr} ${CONFIG}"
+    CONFIG_PRM="-id ${id} ${CONFIG}"
 
     suffix=`echo "${CONFIG}" | tail -c 60 | sed 's/ *$//g'`
 


### PR DESCRIPTION
Fixed a wrong variable name that pass server's id into benchmark-bootstrap server node.